### PR TITLE
fix: use path image torch encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ f = Flow().add(uses=ImageTorchEncoder)
 ### 🐳 Via Docker
 1. Clone the repo and build the docker image
 ```bash
-git clone https://github.com/jina-ai/executor-text-paddle.git
+git clone https://github.com/jina-ai/executor-image-torch-encoder/
+
 cd executor-image-torch-encoder 
 docker build -t jinahub-image-torch-encoder .
 ```

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+pillow==8.2
 pytest==6.2.4
 pytest-mock==3.6.1
 pytest-lazy-fixture==0.6.3


### PR DESCRIPTION
I guess that the path `git clone https://github.com/jina-ai/executor-text-paddle.git` was incorrect