### PR TITLE
fix: make source-code use work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM jinaai/jina:2.0.9-py37-perf
+FROM jinaai/jina:2.0-py37-perf
 
 RUN apt-get update && apt install -y git
 
-COPY . ./image_torch_encoder/
-WORKDIR ./image_torch_encoder
-
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 # setup the workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM jinaai/jina:2.0.3
+FROM jinaai/jina:2.0.9-py37-perf
 
 RUN apt-get update && apt install -y git
 
 COPY . ./image_torch_encoder/
 WORKDIR ./image_torch_encoder
 
-RUN pip install .
+RUN pip install -r requirements.txt
 
 # setup the workspace
 COPY . /workspace

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,5 @@ with:
   {}
 metas:
   py_modules:
+    - models.py
     - torch_encoder.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-jina~=2.0
 torch==1.9.0
 torchvision==0.10.0
 pillow==8.2
 jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.1#egg=jina-commons
-lz4~=3.1

--- a/torch_encoder.py
+++ b/torch_encoder.py
@@ -11,7 +11,7 @@ import torch
 from jina import Executor, requests, DocumentArray
 from jina_commons.batching import get_docs_batch_generator
 
-from jinahub.image.encoder.models import EmbeddingModelWrapper
+from models import EmbeddingModelWrapper
 
 
 class ImageTorchEncoder(Executor):


### PR DESCRIPTION
The following import statement in `torch_encoder.py` cannot work with directly use source code via `jinahub://ImageTorchEncoder`:

```
from jinahub.image.encoder.models import EmbeddingModelWrapper
```

To enable the above import to work, we need to setup the executor via `pip install .` at first. However,  this installing step is not allowed when we using `jinahub://ImageTorchEncoder`. 

In this PR, i handle the extra dependency by appending `py-modules`
```
py-modules:
  - models.py
  - torch_encoder.py
```